### PR TITLE
Don't replace an existing menu, but extend it...

### DIFF
--- a/gm4-polyfill.js
+++ b/gm4-polyfill.js
@@ -63,7 +63,6 @@ if (typeof GM_registerMenuCommand == 'undefined') {
       document.body.appendChild(menu);
       document.body.setAttribute('contextmenu', 'gm-registered-menu');
     }
-    document.body.setAttribute('contextmenu', menu.getAttribute('id'));
     let menuItem = document.createElement('menuitem');
     menuItem.textContent = caption;
     menuItem.addEventListener('click', commandFunc, true);

--- a/gm4-polyfill.js
+++ b/gm4-polyfill.js
@@ -52,7 +52,10 @@ if (typeof GM_registerMenuCommand == 'undefined') {
       console.error('GM_registerMenuCommand got no body.');
       return;
     }
-    let menu = document.getElementById('gm-registered-menu');
+    let menu = null;
+    if (document.body.getAttribute('contextmenu')) {
+        menu = document.querySelector('menu#'+document.body.getAttribute('contextmenu'));
+    }
     if (!menu) {
       menu = document.createElement('menu')
       menu.setAttribute('id', 'gm-registered-menu');
@@ -60,6 +63,7 @@ if (typeof GM_registerMenuCommand == 'undefined') {
       document.body.appendChild(menu);
       document.body.setAttribute('contextmenu', 'gm-registered-menu');
     }
+    document.body.setAttribute('contextmenu', menu.getAttribute('id'));
     let menuItem = document.createElement('menuitem');
     menuItem.textContent = caption;
     menuItem.addEventListener('click', commandFunc, true);


### PR DESCRIPTION
If the page (or another userscript) had already defined a context-menu on body (with an id different from 'gm-registered-menu'), the old version of registerMenuCommand would delete/replace the existing menu. This version always re-uses (extends) an existing context-menu on body element, no matter what id it was given.