### PR TITLE
Update function() arguments to be compatible with Pale Moon

### DIFF
--- a/gm4-polyfill.js
+++ b/gm4-polyfill.js
@@ -93,10 +93,10 @@ Object.entries({
 }).forEach(([oldKey, newKey]) => {
   let old = this[oldKey];
   if (old && (typeof GM[newKey] == 'undefined')) {
-    GM[newKey] = function() {
+    GM[newKey] = function(...args) {
       return new Promise((resolve, reject) => {
         try {
-          resolve(old.apply(this, arguments));
+          resolve(old.apply(this, args));
         } catch (e) {
           reject(e);
         }


### PR DESCRIPTION
Using `function()` - `arguments` in Pale Moon has not been implemented.

IMHO: A simple solution to this is to make a small modification of the code.

Thank you in advance.

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=889158
https://github.com/janekptacijarabaci/greasemonkey/issues/9
https://github.com/greasemonkey/gm4-polyfill/commit/d58c4f6fbe5702dbf849a04d12bca2f5d635862d
