### PR TITLE
Change so the code can be used in "use strict"; mode.

### DIFF
--- a/gm4-polyfill.js
+++ b/gm4-polyfill.js
@@ -24,98 +24,102 @@ Greasemonkey 4.
     })();
 */
 
-if (typeof GM == 'undefined') {
-  GM = {};
-}
+(() => {
+  'use strict';
 
-
-if (typeof GM_addStyle == 'undefined') {
-  this.GM_addStyle = (aCss) => {
-    'use strict';
-    let head = document.getElementsByTagName('head')[0];
-    if (head) {
-      let style = document.createElement('style');
-      style.setAttribute('type', 'text/css');
-      style.textContent = aCss;
-      head.appendChild(style);
-      return style;
-    }
-    return null;
-  };
-}
-
-
-if (typeof GM_registerMenuCommand == 'undefined') {
-  this.GM_registerMenuCommand = (caption, commandFunc, accessKey) => {
-    if (!document.body) {
-      console.error('GM_registerMenuCommand got no body.');
-      return;
-    }
-    let contextMenu = document.body.getAttribute('contextmenu');
-    let menu = (contextMenu ? document.querySelector('menu#' + contextMenu) : null);
-    if (!menu) {
-      menu = document.createElement('menu');
-      menu.setAttribute('id', 'gm-registered-menu');
-      menu.setAttribute('type', 'context');
-      document.body.appendChild(menu);
-      document.body.setAttribute('contextmenu', 'gm-registered-menu');
-    }
-    let menuItem = document.createElement('menuitem');
-    menuItem.textContent = caption;
-    menuItem.addEventListener('click', commandFunc, true);
-    menu.appendChild(menuItem);
-  };
-}
-
-
-if (typeof GM_getResourceText == 'undefined') {
-  this.GM_getResourceText = (aRes) => {
-    'use strict';
-    return GM.getResourceUrl(aRes)
-      .then(url => fetch(url))
-      .then(resp => resp.text())
-      .catch(function(error) {
-        GM.log('Request failed', error);
-        return null;
-      });
-  };
-}
-
-
-Object.entries({
-  'log': console.log,
-  'info': GM_info,
-}).forEach(([newKey, old]) => {
-  if (old && (typeof GM[newKey] == 'undefined')) {
-    GM[newKey] = old;
+  let global = Function('return this;')();
+  if (typeof global.GM == 'undefined') {
+    global.GM = {};
   }
-});
+  let GM = global.GM;
 
 
-Object.entries({
-  'GM_addStyle': 'addStyle',
-  'GM_deleteValue': 'deleteValue',
-  'GM_getResourceURL': 'getResourceUrl',
-  'GM_getValue': 'getValue',
-  'GM_listValues': 'listValues',
-  'GM_notification': 'notification',
-  'GM_openInTab': 'openInTab',
-  'GM_registerMenuCommand': 'registerMenuCommand',
-  'GM_setClipboard': 'setClipboard',
-  'GM_setValue': 'setValue',
-  'GM_xmlhttpRequest': 'xmlHttpRequest',
-  'GM_getResourceText': 'getResourceText',
-}).forEach(([oldKey, newKey]) => {
-  let old = this[oldKey];
-  if (old && (typeof GM[newKey] == 'undefined')) {
-    GM[newKey] = function(...args) {
-      return new Promise((resolve, reject) => {
-        try {
-          resolve(old.apply(this, args));
-        } catch (e) {
-          reject(e);
-        }
-      });
+  if (typeof global.GM_addStyle == 'undefined') {
+    global.GM_addStyle = (aCss) => {
+      let head = document.getElementsByTagName('head')[0];
+      if (head) {
+        let style = document.createElement('style');
+        style.setAttribute('type', 'text/css');
+        style.textContent = aCss;
+        head.appendChild(style);
+        return style;
+      }
+      return null;
     };
   }
-});
+
+
+  if (typeof global.GM_registerMenuCommand == 'undefined') {
+    global.GM_registerMenuCommand = (caption, commandFunc, accessKey) => {
+      if (!document.body) {
+        console.error('GM_registerMenuCommand got no body.');
+        return;
+      }
+      let contextMenu = document.body.getAttribute('contextmenu');
+      let menu = (contextMenu ? document.querySelector('menu#' + contextMenu) : null);
+      if (!menu) {
+        menu = document.createElement('menu');
+        menu.setAttribute('id', 'gm-registered-menu');
+        menu.setAttribute('type', 'context');
+        document.body.appendChild(menu);
+        document.body.setAttribute('contextmenu', 'gm-registered-menu');
+      }
+      let menuItem = document.createElement('menuitem');
+      menuItem.textContent = caption;
+      menuItem.addEventListener('click', commandFunc, true);
+      menu.appendChild(menuItem);
+    };
+  }
+
+
+  if (typeof global.GM_getResourceText == 'undefined') {
+    global.GM_getResourceText = (aRes) => {
+      return GM.getResourceUrl(aRes)
+        .then(url => fetch(url))
+        .then(resp => resp.text())
+        .catch(function(error) {
+          GM.log('Request failed', error);
+          return null;
+        });
+    };
+  }
+
+
+  Object.entries({
+    'log': console.log,
+    'info': global.GM_info,
+  }).forEach(([newKey, old]) => {
+    if (old && (typeof GM[newKey] == 'undefined')) {
+      GM[newKey] = old;
+    }
+  });
+
+
+  Object.entries({
+    'GM_addStyle': 'addStyle',
+    'GM_deleteValue': 'deleteValue',
+    'GM_getResourceURL': 'getResourceUrl',
+    'GM_getValue': 'getValue',
+    'GM_listValues': 'listValues',
+    'GM_notification': 'notification',
+    'GM_openInTab': 'openInTab',
+    'GM_registerMenuCommand': 'registerMenuCommand',
+    'GM_setClipboard': 'setClipboard',
+    'GM_setValue': 'setValue',
+    'GM_xmlhttpRequest': 'xmlHttpRequest',
+    'GM_getResourceText': 'getResourceText',
+  }).forEach(([oldKey, newKey]) => {
+    let old = global[oldKey] || window[oldKey];
+    if (old && (typeof GM[newKey] == 'undefined')) {
+      GM[newKey] = function(...args) {
+        return new Promise((resolve, reject) => {
+          try {
+            resolve(old.apply(global, args));
+          } catch (e) {
+            reject(e);
+          }
+        });
+      };
+    }
+  });
+})();


### PR DESCRIPTION
The code can be included in a script using @require, or by copying the code into a script (which can be either in strict mode, or not). All changes to `GM.` and `GM_` are made only on the global scope. "use strict"; is used for the entire script, but in an IIFE, so that choice does not affect the including script (i.e. the including script can be in strict mode, or not).

Tested as  both `@required` and copy-&-pasted into a script in the following browsers/user script managers [Note abbreviations: Greasemonkey 4 (GM4), Greasemonkey 3.17 (GM3), Tampermonkey (TM), and Violentmonkey (VM)]:

* Windows 10 x64
  * Firefox 57: GM4, TM, VM
  * Firefox 56.0.2: GM4, GM3, TM, VM
  * Firefox ESR 52.5.2: GM3, TM, VM: ([GM4: `GM.setValue` & `GM.getValue()` are broken in Firefox ESR 52.5.2](https://github.com/greasemonkey/greasemonkey/issues/2781))
  * Chrome 63.0.3239.84 & 63.0.3239.108: TM, VM
  * Edge 41.16299.15.0: TM
  * Opera 49.0.2725.64 (PGO): TM
  * Pale Moon 27.6.2: Greasemonkey for Pale Moon 3.30rc4

I only tested under Windows 10 x64, as I grew tired of testing.




