### PR TITLE
Fix: use this.GM

### DIFF
--- a/gm4-polyfill.js
+++ b/gm4-polyfill.js
@@ -25,7 +25,7 @@ Greasemonkey 4.
 */
 
 if (typeof GM == 'undefined') {
-  GM = {};
+  this.GM = {};
 }
 
 


### PR DESCRIPTION
See https://github.com/greasemonkey/greasemonkey/issues/2784.

I have only tested it on Tamper/Violentmonkey on Firefox 58.

Another problem is that the `@require` demo in the README probably should include the commit hash so that script authors can make sure everyone would download the same file (use the same code). The latest commit hash, however, would change each time a PR is merged. I'm not sure if there is a good way to update it. Maybe we can add a warning for this problem to README first.

BTW, may I ask the reason for [not using issues for this repo](https://github.com/greasemonkey/greasemonkey/issues/2787)? I put https://github.com/greasemonkey/greasemonkey/issues/2784 under Greasemonkey because I found that I can't put it here.
