### PR TITLE
Update GM.log (console.log) to be compatible with Pale Moon

### DIFF
--- a/gm4-polyfill.js
+++ b/gm4-polyfill.js
@@ -83,7 +83,7 @@ if (typeof GM_getResourceText == 'undefined') {
 
 
 Object.entries({
-  'log': console.log,
+  'log': console.log.bind(console),
   'info': GM_info,
 }).forEach(([newKey, old]) => {
   if (old && (typeof GM[newKey] == 'undefined')) {


### PR DESCRIPTION
[Bug 989619](https://bugzilla.mozilla.org/show_bug.cgi?id=989619) is not implemented in Pale Moon.

`GM.log("log");`
throws:
`'log' called on an object that does not implement interface Console.`

This PR tested for:
Greasemonkey 3.11 (Firefox 52 ESR)
Greasemonkey 4.1 (Firefox 59)
Violentmonkey 2.8.23 / Tampermonkey 4.4 (Chrome 62)

If someone doesn't see a problem, I please you add it.
